### PR TITLE
Refactored Copy and Rename environments

### DIFF
--- a/CCMS/src/Environment/D4PBCEnvironmentList.page.al
+++ b/CCMS/src/Environment/D4PBCEnvironmentList.page.al
@@ -316,13 +316,13 @@ page 62003 "D4P BC Environment List"
                 trigger OnAction()
                 var
                     BCTenant: Record "D4P BC Tenant";
-                    CopyEnvironmentDialog: Page "D4P Copy Environment Dialog";
+                    RenameEnvironmentDialog: Page "D4P Rename Environment Dialog";
                 begin
                     BCTenant.Get(Rec."Customer No.", Rec."Tenant ID");
-                    CopyEnvironmentDialog.SetBCTenant(BCTenant);
-                    CopyEnvironmentDialog.SetCurrentBCEnvironment(Rec.Name);
-                    if CopyEnvironmentDialog.RunModal() = Action::OK then begin
-                        CopyEnvironmentDialog.CopyEnvironment();
+                    RenameEnvironmentDialog.SetBCTenant(BCTenant);
+                    RenameEnvironmentDialog.SetCurrentBCEnvironment(Rec.Name);
+                    if RenameEnvironmentDialog.RunModal() = Action::OK then begin
+                        RenameEnvironmentDialog.RenameEnvironment();
                     end;
                 end;
             }

--- a/CCMS/src/Environment/D4PBCEnvironmentMgt.codeunit.al
+++ b/CCMS/src/Environment/D4PBCEnvironmentMgt.codeunit.al
@@ -523,8 +523,8 @@ codeunit 62000 "D4P BC Environment Mgt"
         JsonObject.Add('environmentName', NewEnvironmentName);
         JsonObject.Add('type', Format(NewEnvironmentType));
 
-        if not APIHelper.SendAdminAPIRequest(BCTenant, 'PUT',
-            '/applications/businesscentral/environments/' + SourceEnvironmentName + '/copy/',
+        if not APIHelper.SendAdminAPIRequest(BCTenant, 'POST',
+            '/applications/businesscentral/environments/' + SourceEnvironmentName + '/copy',
             Format(JsonObject), ResponseText) then
             Error(FailedToCreateErr, ResponseText);
 


### PR DESCRIPTION
Fixed Copy and Rename environment operations:

- Fixed Copy environment API call: changed from PUT to POST and removed trailing slash from endpoint
- Fixed Rename environment action: now correctly uses Rename dialog instead of Copy dialog
