### PR TITLE
Remove NAB tags for the build

### DIFF
--- a/.AL-Go/PreCompileApp.ps1
+++ b/.AL-Go/PreCompileApp.ps1
@@ -5,11 +5,7 @@ Param(
 
 Get-ChildItem -path (Join-Path $compilationParams.Value.appProjectFolder "Translations") -Filter *.xlf -Recurse | ForEach-Object {
     Write-Host "Found translation file: $($_.FullName)"
-    Write-Host "---------------------------------------------- BEFORE -----------------------------------------------"
-    Get-Content -Path $_.FullName | Out-Host
     # Remove NAB tags before compiling
-    Get-Content -Path $_.FullName | ForEach-Object { $_ -replace '\[NAB:[^<>\[\]]*\]','' } | Set-Content -Path $_.FullName
-    Write-Host "---------------------------------------------- AFTER -----------------------------------------------"
-    Get-Content -Path $_.FullName | Out-Host
-    Write-Host "---------------------------------------------- END -----------------------------------------------"
+    $lines = Get-Content -Path $_.FullName -Encoding UTF8 | ForEach-Object { $_ -replace '\[NAB:[^<>\[\]]*\]','' }
+    Set-Content -Path $_.FullName -Value $lines -Encoding UTF8
 }


### PR DESCRIPTION
When strings are not translated or needs review, translation files will contain items like:

<img width="421" height="141" alt="image" src="https://github.com/user-attachments/assets/c194efb3-f6f0-4ee8-a10e-b2b974ebb99f" />

This fix will remove the tags from the build, but leave them in the source

<img width="361" height="108" alt="image" src="https://github.com/user-attachments/assets/d3646486-2bc6-4297-82f1-1e3a8ca9cbcc" />
