### PR TITLE
Update Business Central Admin API Base URL to v2.28 in tooltip

### DIFF
--- a/CCMS/Translations/Cloud Customer Management Solution.da-DK.xlf
+++ b/CCMS/Translations/Cloud Customer Management Solution.da-DK.xlf
@@ -4352,8 +4352,8 @@
           <note from="Xliff Generator" annotates="general" priority="3">Page D4P BC Setup - Control API - Property Caption</note>
         </trans-unit>
         <trans-unit id="Page 1013162530 - Control 1921896107 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Base URL for Business Central Admin API calls. Default: https://api.businesscentral.dynamics.com/admin/v2.24</source>
-          <target>Basis-URL for Business Central Admin API-kald. Standard: https://api.businesscentral.dynamics.com/admin/v2.24</target>
+          <source>Base URL for Business Central Admin API calls. Default: https://api.businesscentral.dynamics.com/admin/v2.28</source>
+          <target>Basis-URL for Business Central Admin API-kald. Standard: https://api.businesscentral.dynamics.com/admin/v2.28</target>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Page D4P BC Setup - Control Admin API Base URL - Property ToolTip</note>
         </trans-unit>

--- a/CCMS/Translations/Cloud Customer Management Solution.de-DE.xlf
+++ b/CCMS/Translations/Cloud Customer Management Solution.de-DE.xlf
@@ -4353,8 +4353,8 @@
           <note from="Xliff Generator" annotates="general" priority="3">Page D4P BC Setup - Control API - Property Caption</note>
         </trans-unit>
         <trans-unit id="Page 1013162530 - Control 1921896107 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Base URL for Business Central Admin API calls. Default: https://api.businesscentral.dynamics.com/admin/v2.24</source>
-          <target>Basis-URL für Business Central Admin-API-Aufrufe. Standard: https://api.businesscentral.dynamics.com/admin/v2.24</target>
+          <source>Base URL for Business Central Admin API calls. Default: https://api.businesscentral.dynamics.com/admin/v2.28</source>
+          <target>Basis-URL für Business Central Admin-API-Aufrufe. Standard: https://api.businesscentral.dynamics.com/admin/v2.28</target>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Page D4P BC Setup - Control Admin API Base URL - Property ToolTip</note>
         </trans-unit>

--- a/CCMS/Translations/Cloud Customer Management Solution.es-ES.xlf
+++ b/CCMS/Translations/Cloud Customer Management Solution.es-ES.xlf
@@ -4353,8 +4353,8 @@
           <note from="Xliff Generator" annotates="general" priority="3">Page D4P BC Setup - Control API - Property Caption</note>
         </trans-unit>
         <trans-unit id="Page 1013162530 - Control 1921896107 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Base URL for Business Central Admin API calls. Default: https://api.businesscentral.dynamics.com/admin/v2.24</source>
-          <target>URL base para llamadas a la API de administración de Business Central. Predeterminado: https://api.businesscentral.dynamics.com/admin/v2.24</target>
+          <source>Base URL for Business Central Admin API calls. Default: https://api.businesscentral.dynamics.com/admin/v2.28</source>
+          <target>URL base para llamadas a la API de administración de Business Central. Predeterminado: https://api.businesscentral.dynamics.com/admin/v2.28</target>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Page D4P BC Setup - Control Admin API Base URL - Property ToolTip</note>
         </trans-unit>

--- a/CCMS/Translations/Cloud Customer Management Solution.fi-FI.xlf
+++ b/CCMS/Translations/Cloud Customer Management Solution.fi-FI.xlf
@@ -4348,8 +4348,8 @@
           <note from="Xliff Generator" annotates="general" priority="3">Page D4P BC Setup - Control API - Property Caption</note>
         </trans-unit>
         <trans-unit id="Page 1013162530 - Control 1921896107 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Base URL for Business Central Admin API calls. Default: https://api.businesscentral.dynamics.com/admin/v2.24</source>
-          <target>Perus-URL Business Central -hallinta-API-kutsuille. Oletus: https://api.businesscentral.dynamics.com/admin/v2.24</target>
+          <source>Base URL for Business Central Admin API calls. Default: https://api.businesscentral.dynamics.com/admin/v2.28</source>
+          <target>Perus-URL Business Central -hallinta-API-kutsuille. Oletus: https://api.businesscentral.dynamics.com/admin/v2.28</target>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Page D4P BC Setup - Control Admin API Base URL - Property ToolTip</note>
         </trans-unit>

--- a/CCMS/Translations/Cloud Customer Management Solution.fr-FR.xlf
+++ b/CCMS/Translations/Cloud Customer Management Solution.fr-FR.xlf
@@ -4352,8 +4352,8 @@
           <note from="Xliff Generator" annotates="general" priority="3">Page D4P BC Setup - Control API - Property Caption</note>
         </trans-unit>
         <trans-unit id="Page 1013162530 - Control 1921896107 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Base URL for Business Central Admin API calls. Default: https://api.businesscentral.dynamics.com/admin/v2.24</source>
-          <target>URL de base pour les appels à l'API d'administration Business Central. Par défaut : https://api.businesscentral.dynamics.com/admin/v2.24</target>
+          <source>Base URL for Business Central Admin API calls. Default: https://api.businesscentral.dynamics.com/admin/v2.28</source>
+          <target>URL de base pour les appels à l'API d'administration Business Central. Par défaut : https://api.businesscentral.dynamics.com/admin/v2.28</target>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Page D4P BC Setup - Control Admin API Base URL - Property ToolTip</note>
         </trans-unit>

--- a/CCMS/Translations/Cloud Customer Management Solution.it-IT.xlf
+++ b/CCMS/Translations/Cloud Customer Management Solution.it-IT.xlf
@@ -4353,8 +4353,8 @@
           <note from="Xliff Generator" annotates="general" priority="3">Page D4P BC Setup - Control API - Property Caption</note>
         </trans-unit>
         <trans-unit id="Page 1013162530 - Control 1921896107 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Base URL for Business Central Admin API calls. Default: https://api.businesscentral.dynamics.com/admin/v2.24</source>
-          <target>URL base per le chiamate API Admin di Business Central. Predefinito: https://api.businesscentral.dynamics.com/admin/v2.24</target>
+          <source>Base URL for Business Central Admin API calls. Default: https://api.businesscentral.dynamics.com/admin/v2.28</source>
+          <target>URL base per le chiamate API Admin di Business Central. Predefinito: https://api.businesscentral.dynamics.com/admin/v2.28</target>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Page D4P BC Setup - Control Admin API Base URL - Property ToolTip</note>
         </trans-unit>

--- a/CCMS/Translations/Cloud Customer Management Solution.nb-NO.xlf
+++ b/CCMS/Translations/Cloud Customer Management Solution.nb-NO.xlf
@@ -4372,8 +4372,8 @@
           <note from="Xliff Generator" annotates="general" priority="3">Page D4P BC Setup - Control API - Property Caption</note>
         </trans-unit>
         <trans-unit id="Page 1013162530 - Control 1921896107 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
-          <source>Base URL for Business Central Admin API calls. Default: https://api.businesscentral.dynamics.com/admin/v2.24</source>
-          <target>Base URL for Business Central Admin API kall. Standard: https://api.businesscentral.dynamics.com/admin/v2.24</target>
+          <source>Base URL for Business Central Admin API calls. Default: https://api.businesscentral.dynamics.com/admin/v2.28</source>
+          <target>Base URL for Business Central Admin API kall. Standard: https://api.businesscentral.dynamics.com/admin/v2.28</target>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Page D4P BC Setup - Control Admin API Base URL - Property ToolTip</note>
         </trans-unit>

--- a/CCMS/src/Setup/D4PBCSetupPage.page.al
+++ b/CCMS/src/Setup/D4PBCSetupPage.page.al
@@ -29,7 +29,7 @@ page 62010 "D4P BC Setup"
                 field("Admin API Base URL"; Rec."Admin API Base URL")
                 {
                     ApplicationArea = All;
-                    ToolTip = 'Base URL for Business Central Admin API calls. Default: https://api.businesscentral.dynamics.com/admin/v2.24';
+                    ToolTip = 'Base URL for Business Central Admin API calls. Default: https://api.businesscentral.dynamics.com/admin/v2.28';
                 }
                 field("Automation API Base URL"; Rec."Automation API Base URL")
                 {


### PR DESCRIPTION
Fixes #84 

- The Admin API Base URL tooltip is out of sync with the code.
- 2.28 is the new default instead of 2.24
