### PR TITLE
[Feature] Admin Center Quick Access

### DIFF
--- a/CCMS/src/Tenant/D4PBCTenant.table.al
+++ b/CCMS/src/Tenant/D4PBCTenant.table.al
@@ -108,4 +108,12 @@ table 62001 "D4P BC Tenant"
 
         ClientSecret := AppRegistration.GetClientSecret("Client ID");
     end;
+
+    internal procedure OpenAdminCenter()
+    begin
+        if IsNullGuid("Tenant ID") then
+            exit;
+
+        Hyperlink(StrSubstNo('https://businesscentral.dynamics.com/%1/admin', "Tenant ID".ToText().ToLower().Replace('{', '').Replace('}', '')));
+    end;
 }

--- a/CCMS/src/Tenant/D4PBCTenantCard.page.al
+++ b/CCMS/src/Tenant/D4PBCTenantCard.page.al
@@ -116,6 +116,17 @@ page 62011 "D4P BC Tenant Card"
     {
         area(Navigation)
         {
+            action(AdminCenter)
+            {
+                ApplicationArea = All;
+                Caption = 'Admin Center';
+                Image = LaunchWeb;
+                ToolTip = 'Open the Dynamics 365 Business Central Admin Center for this tenant.';
+                trigger OnAction()
+                begin
+                    Rec.OpenAdminCenter();
+                end;
+            }
             action(Environments)
             {
                 ApplicationArea = All;

--- a/CCMS/src/Tenant/D4PBCTenantList.page.al
+++ b/CCMS/src/Tenant/D4PBCTenantList.page.al
@@ -73,6 +73,17 @@ page 62002 "D4P BC Tenant List"
         }
         area(Navigation)
         {
+            action(AdminCenter)
+            {
+                ApplicationArea = All;
+                Caption = 'Admin Center';
+                Image = LaunchWeb;
+                ToolTip = 'Open the Dynamics 365 Business Central Admin Center for this tenant.';
+                trigger OnAction()
+                begin
+                    Rec.OpenAdminCenter();
+                end;
+            }
             action(Environments)
             {
                 ApplicationArea = All;
@@ -99,6 +110,9 @@ page 62002 "D4P BC Tenant List"
             group(Category_Navigation)
             {
                 Caption = 'Navigation';
+                actionref(AdminCenterPromoted; AdminCenter)
+                {
+                }
                 actionref(EnvironmentsPromoted; Environments)
                 {
                 }


### PR DESCRIPTION
Fixes #109

## Admin Center Quick Access for Tenant Management

### Description
Added a new 'Admin Center' action to the Tenant Card and Tenant List pages, enabling users to quickly open the Dynamics 365 Business Central Admin Center for a selected tenant.

<img width="818" height="359" alt="image" src="https://github.com/user-attachments/assets/f2b3c1ca-15b1-46a1-bbf8-941c12a7a013" />

### Changes

#### Tenant Table (D4PBCTenant.table.al)
- Added `OpenAdminCenter()` internal procedure
- Opens hyperlink: `https://businesscentral.dynamics.com/{Tenant ID}/admin`

#### Tenant Card Page (D4PBCTenantCard.page.al)
- Added 'Admin Center' action in Navigation area

#### Tenant List Page (D4PBCTenantList.page.al)
- Added 'Admin Center' action in Navigation area